### PR TITLE
Allow working with dynamic keys

### DIFF
--- a/lib/axolotl/proto.js
+++ b/lib/axolotl/proto.js
@@ -28,24 +28,10 @@ function Axolotl(mode) {
   else
     throw new "Eve's has been caught!"; // TODO(kudinkin): Exception class?
 
-  // TODO(kudinkin): Preserve stability during debug 
-  //self.state = {
-  //  DHI:  self.generateKeyPair(), /* Identity KP */
-  //  DHHS: self.generateKeyPair(), /* Handshake KP */
-  //  DHR:  self.generateKeyPair(), /* Ratcheting KP */
-  //}
-  if (self.mode === 'alice') {
-    self.state = {
-      DHI:  djb.keyFromPrivate("036be82be5e3f8e49390062c3c1ed92b76b83dfab6e1c228f3fd79f8ee8136b8", 16),
-      DHHS: djb.keyFromPrivate("04a5c651202d7193c5089fb8b3336368f00bb6ae4c8df5f7eabe11b61a4f9cdd", 16),
-      DHR:  djb.keyFromPrivate("027ecf5d60bd50d472ced827445772b37c739c6bdf2b33eed5cf28702f7610fd", 16) 
-    };
-  } else {
-    self.state = {
-      DHI:  djb.keyFromPrivate("0f49b0afabb388e30c6d2f5a3c937f05f3568eb3223aa328bc880421e4c71c77", 16),
-      DHHS: djb.keyFromPrivate("03a01653b472beb112ca05356c9d2e300d0a724269c057690290efba1cfd0cd9", 16),
-      DHR:  djb.keyFromPrivate("08e713c55d1f22289a2533e296a8fd42ea4fb6d2370c6d28cd05b20602e6162d", 16) 
-    };
+  self.state = {
+    DHI:  self.generateKeyPair(), /* Identity KP */
+    DHHS: self.generateKeyPair(), /* Handshake KP */
+    DHR:  self.generateKeyPair(), /* Ratcheting KP */
   }
 }
 
@@ -79,12 +65,6 @@ Axolotl.prototype.init = function init(other, verify) {
   assert(other.identity   && other.identity.PK);
   assert(other.handshake  && other.handshake.PK);
   assert(other.ratchet    && other.ratchet.PK);
-
-  // TODO(kudinkin): Shim this?
-  if (self.state.DHI.getPublic().getX() < other.identity.PK.getX())
-    self.mode = 'alice';
-  else
-    self.mode = 'bob'; 
 
   self.state.DHIr = other.identity.PK;
   


### PR DESCRIPTION
1. Deleted static keys from `Axolotol` c'tor
2. Deleted change of mode due to DHI key comparison in `Axolotol.init(other, verify)`
